### PR TITLE
♻️ Refacto of group utils 

### DIFF
--- a/src/group/types.ts
+++ b/src/group/types.ts
@@ -10,7 +10,7 @@ export interface GroupData {
 
 export interface GroupInfo {
     desc: string;
-    provider: string[];
+    providers: string[];
     logo?: string;
     groups?: GroupsPulumiInfo;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ function deploy (): Output {
 
     const groups = group.initGroup(
         providers,
-        config.requireObject<GroupsPulumiConfig>("groupConfigs"),
-        config.requireObject<GroupsPulumiInfo>("groups")
+        config.requireObject<GroupsPulumiInfo>("groups"),
+        config.getObject<GroupsPulumiConfig>("groupConfigs")
     );
 
     return {

--- a/stacks-example/Pulumi.example.yaml
+++ b/stacks-example/Pulumi.example.yaml
@@ -49,5 +49,5 @@ config:
       # Description of the group
       desc: My Test group description
       # List of provider where to create the group, must be among `gitProvider` key
-      provider:
+      providers:
         - provider_name.tld

--- a/stacks-example/Pulumi.example_full.yaml
+++ b/stacks-example/Pulumi.example_full.yaml
@@ -30,5 +30,5 @@ config:
   git-repo:groups:
     my_group:
       desc: My Test group description
-      provider:
+      providers:
         - provider_name.tld

--- a/stacks-example/Pulumi.example_minimum.yaml
+++ b/stacks-example/Pulumi.example_minimum.yaml
@@ -14,6 +14,6 @@ config:
   git-repo:groups:
     my_group:
       desc: My Test group descrpition
-      provider:
+      providers:
         - provider_name.tld
         - another_provider_name

--- a/stacks-example/Pulumi.example_target.yaml
+++ b/stacks-example/Pulumi.example_target.yaml
@@ -330,7 +330,7 @@ config:
     my_group:
       desc: My group desctipn
       logo: ./img/namespace/my_group_logo.png
-      provider:
+      providers:
         - framagit.org
         - gitlab.com # will be a mirror of group at framagit.org
         - github.com # will be a mirror of group at framagit.org

--- a/tests/group/utils.ts
+++ b/tests/group/utils.ts
@@ -54,14 +54,13 @@ test("group with unsupported provider", (currTest) => {
         "fakeGroupName": {
             "desc": GROUP_DESC,
             // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-            "provider": [PROVIDER_NAME[2]]
+            "providers": [PROVIDER_NAME[2]]
         }
     };
 
     const providers = provider.initProvider(PROVIDER);
     const groups = group.initGroup(
         providers,
-        {},
         fakeGroups
     );
 
@@ -73,14 +72,13 @@ test("group with supported provider without group args", (currTest) => {
         "fakeGroupName": {
             "desc": GROUP_DESC,
             // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-            "provider": [PROVIDER_NAME[0]]
+            "providers": [PROVIDER_NAME[0]]
         }
     };
 
     const providers = provider.initProvider(PROVIDER);
     const groups = group.initGroup(
         providers,
-        {},
         fakeGroups
     );
 
@@ -95,7 +93,7 @@ test("group with supported provider with default group args", (currTest) => {
         "fakeGroupName": {
             "desc": GROUP_DESC,
             // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-            "provider": [PROVIDER_NAME[0]]
+            "providers": [PROVIDER_NAME[0]]
         }
     };
 
@@ -108,8 +106,8 @@ test("group with supported provider with default group args", (currTest) => {
     const providers = provider.initProvider(PROVIDER);
     const groups = group.initGroup(
         providers,
-        fakeGroupConfigs,
-        fakeGroups
+        fakeGroups,
+        fakeGroupConfigs
     );
 
 
@@ -124,7 +122,7 @@ test("group with supported provider mirror groups args", (currTest) => {
         "fakeGroupName": {
             "desc": GROUP_DESC,
             // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-            "provider": [PROVIDER_NAME[0], PROVIDER_NAME[1]]
+            "providers": [PROVIDER_NAME[0], PROVIDER_NAME[1]]
         }
     };
 
@@ -138,8 +136,8 @@ test("group with supported provider mirror groups args", (currTest) => {
     const providers = provider.initProvider(PROVIDER);
     const groups = group.initGroup(
         providers,
-        fakeGroupConfigs,
-        fakeGroups
+        fakeGroups,
+        fakeGroupConfigs
     );
 
     currTest.is(
@@ -160,11 +158,11 @@ test("group with supported provider with subgroup", (currTest) => {
             "groups": {
                 "fakeGroupName": {
                     "desc": GROUP_DESC,
-                    "provider": []
+                    "providers": []
                 }
             },
             // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-            "provider": [PROVIDER_NAME[0]]
+            "providers": [PROVIDER_NAME[0]]
         }
     };
 
@@ -178,8 +176,8 @@ test("group with supported provider with subgroup", (currTest) => {
     const providers = provider.initProvider(PROVIDER);
     const groups = group.initGroup(
         providers,
-        fakeGroupConfigs,
-        fakeGroups
+        fakeGroups,
+        fakeGroupConfigs
     );
 
     currTest.is(


### PR DESCRIPTION
Refactorisation of group utils to use key `providers` instead of `provider` in groups list.
Update test and stack example accordingly.