### PR TITLE
✨ Add Github provider support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
+    "@pulumi/github": "^5.3.0",
     "@pulumi/gitlab": "^4.9.0",
     "@pulumi/pulumi": "^3.0.0"
   },

--- a/src/provider/factory.ts
+++ b/src/provider/factory.ts
@@ -2,6 +2,7 @@ import type {
     ProviderData,
     ProviderSupportedObject
 } from "./types";
+import {GithubProvider} from "./github";
 import {GitlabProvider} from "./gitlab";
 
 /**
@@ -22,6 +23,8 @@ export function providerFactory (
 ): ProviderSupportedObject {
     if (type === "gitlab") {
         return new GitlabProvider(name, data.args, data.opts);
+    } else if (type === "github") {
+        return new GithubProvider(name, data.args, data.opts);
     }
     throw new Error(`Git provider type not supported: "${type}"`);
 }

--- a/src/provider/github.ts
+++ b/src/provider/github.ts
@@ -1,0 +1,59 @@
+import * as github from "@pulumi/github";
+import type * as group from "../group";
+import type * as project from "../project";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface IGithubProvider {
+    name: string;
+    provider: github.Provider;
+    groups: group.GroupsDict;
+    projects: project.ProjectsDict;
+}
+
+
+/**
+ * Pulumi custom ComponentResource which deploy a github provider and its
+ * associated API client.
+ *
+ * @augments pulumi.ComponentResource
+ * @implements {IGithubProvider} IGithubProvider
+ */
+export class GithubProvider extends pulumi.ComponentResource
+    implements IGithubProvider {
+
+    public readonly providerType = "github";
+
+    public name = "";
+
+    public provider: github.Provider;
+
+    public groups: group.GroupsDict = {};
+
+    public projects: project.ProjectsDict = {};
+
+    /**
+     * Constructor of the ComponentResource GithubProvider
+     *
+     * @param {string} name - Name of the provider
+     * @param {github.ProviderArgs} args - Github provider arguments
+     * @param {pulumi.ComponentResourceOptions} [opts] - Pulumi resources
+     *      options
+     */
+    public constructor (
+        name: string,
+        args: github.ProviderArgs,
+        opts?: pulumi.CustomResourceOptions
+    ) {
+        super(`git-repo:github-provider:${name}`, name, args, opts);
+        this.name = name;
+        this.provider = new github.Provider(
+            this.name,
+            args,
+            {
+                ...opts,
+                "parent": this
+            }
+        );
+    }
+
+}

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,4 +1,5 @@
 export {GitlabProvider} from "./gitlab";
+export {GithubProvider} from "./github";
 export * from "./factory";
 export * from "./types";
 export * from "./utils";

--- a/src/provider/types.ts
+++ b/src/provider/types.ts
@@ -1,3 +1,4 @@
+import type * as githubProvider from "./github";
 import type * as gitlab from "@pulumi/gitlab";
 import type * as gitlabProvider from "./gitlab";
 import type * as pulumi from "@pulumi/pulumi";
@@ -24,9 +25,11 @@ export interface ProvidersDict {
 
 // Type
 // eslint warning below will not be raised once other provider will be supported
-export type ProviderSupportedObject = gitlabProvider.GitlabProvider;
+export type ProviderSupportedObject =
+    githubProvider.GithubProvider | gitlabProvider.GitlabProvider;
 
 // Enum
 export enum ProviderSupportedType {
-    gitlab = "gitlab"
+    gitlab = "gitlab",
+    github = "github"
 }

--- a/tests/provider/factory.ts
+++ b/tests/provider/factory.ts
@@ -1,4 +1,8 @@
-import {GitlabProvider, providerFactory} from "../../src/provider/";
+import {
+    GithubProvider,
+    GitlabProvider,
+    providerFactory
+} from "../../src/provider/";
 import type {ProviderData} from "../../src/provider/types";
 import test from "ava";
 
@@ -36,5 +40,16 @@ test(
         const provider = providerFactory(gitType, FAKE_NAME, DATA);
 
         currTest.is(typeof provider, typeof GitlabProvider.prototype);
+    }
+);
+
+
+test(
+    "Github git provider",
+    (currTest) => {
+        const gitType = "github";
+        const provider = providerFactory(gitType, FAKE_NAME, DATA);
+
+        currTest.is(typeof provider, typeof GithubProvider.prototype);
     }
 );

--- a/tests/provider/github.ts
+++ b/tests/provider/github.ts
@@ -1,0 +1,27 @@
+import * as github from "../../src/provider/github";
+import type {ProviderData} from "../../src/provider/types";
+import test from "ava";
+
+const FAKE_BASEURL = "https://fake.github.tld";
+const FAKE_TOKEN = "fakeToken";
+const FAKE_NAME = "fakeName";
+const FAKE_ALIAS = "fakeAlias";
+
+test("githubProvider", (currTest) => {
+    const data: ProviderData = {
+        "args": {
+            "baseUrl": FAKE_BASEURL,
+            "token": FAKE_TOKEN
+        },
+        "opts": {
+            "aliases": [{"name": FAKE_ALIAS}]
+        }
+    };
+    const githubProvider = new github.GithubProvider(
+        FAKE_NAME,
+        data.args,
+        data.opts
+    );
+
+    currTest.is(githubProvider.name, FAKE_NAME);
+});

--- a/tests/provider/utils.ts
+++ b/tests/provider/utils.ts
@@ -12,7 +12,7 @@ test("not supported git provider initialization", (currTest) => {
         "fakeName": {
             "baseUrl": FAKE_BASEURL,
             "token": FAKE_TOKEN,
-            "type": "github"
+            "type": "fakeProvider"
         }
     };
     const initProvider = utils.initProvider(data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,6 +855,13 @@
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
 
+"@pulumi/github@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/github/-/github-5.3.0.tgz#6f0746e04988216c5242b7d7a25bf01dbd241351"
+  integrity sha512-TBkgq1Lr5w0v7s3J04qHnOO8OK1swzYqN79PDUdbYva8oyu0MzMB5QOKBszXj4znih2aSlXNDUnSMLLlkAdteQ==
+  dependencies:
+    "@pulumi/pulumi" "^3.0.0"
+
 "@pulumi/gitlab@^4.9.0":
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/@pulumi/gitlab/-/gitlab-4.9.0.tgz#94240fcb6a1a9f4cb690fe65390e49e954a7084d"


### PR DESCRIPTION
Add Github as supported provider.
Does not support Github Groups (aka Organization) neither project for now.

Fixes #60 